### PR TITLE
Hyunbok

### DIFF
--- a/src/main/java/com/examle/sikmogilbackend/member/api/MemberController.java
+++ b/src/main/java/com/examle/sikmogilbackend/member/api/MemberController.java
@@ -48,4 +48,15 @@ public class MemberController {
         return new RspTemplate<>(HttpStatus.OK, "온보딩");
     }
 
+    @Operation(summary = "온보딩 정보 출력", description = "온보딩 정보를 출력합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "온보딩 정보 출력 성공"),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청 값"),
+            @ApiResponse(responseCode = "401", description = "헤더 없음 or 토큰 불일치", content = @Content(schema = @Schema(example = "INVALID_HEADER or INVALID_TOKEN")))
+    })
+    @GetMapping("/getMember")
+    public RspTemplate<OnboardingInfoUpdateReqDto> findMember(@AuthenticationPrincipal String email) {
+        return new RspTemplate<>(HttpStatus.OK, "온보딩 정보 출력", memberService.findMember(email).toDTO());
+    }
+
 }

--- a/src/main/java/com/examle/sikmogilbackend/member/api/dto/reqeust/OnboardingInfoUpdateReqDto.java
+++ b/src/main/java/com/examle/sikmogilbackend/member/api/dto/reqeust/OnboardingInfoUpdateReqDto.java
@@ -7,7 +7,7 @@ public record OnboardingInfoUpdateReqDto(
         String gender,
         String targetWeight,
         String targetDate,
-
+        Long canEatCalorie,
         String createdDate
 ) {
 }

--- a/src/main/java/com/examle/sikmogilbackend/member/api/dto/reqeust/OnboardingInfoUpdateReqDto.java
+++ b/src/main/java/com/examle/sikmogilbackend/member/api/dto/reqeust/OnboardingInfoUpdateReqDto.java
@@ -1,5 +1,8 @@
 package com.examle.sikmogilbackend.member.api.dto.reqeust;
 
+import lombok.Builder;
+
+@Builder
 public record OnboardingInfoUpdateReqDto(
         String nickname,
         String height,

--- a/src/main/java/com/examle/sikmogilbackend/member/application/MemberService.java
+++ b/src/main/java/com/examle/sikmogilbackend/member/application/MemberService.java
@@ -23,6 +23,10 @@ public class MemberService {
                 .isFirstLogin();
     }
 
+    public Member findMember(String email) {
+        return memberRepository.findByEmail(email).orElseThrow(MemberNotFoundException::new);
+    }
+
     @Transactional
     public void onboardingInfoUpdate(String email, OnboardingInfoUpdateReqDto onboardingInfoUpdateReqDto) {
         validateDuplicateNickName(onboardingInfoUpdateReqDto.nickname());

--- a/src/main/java/com/examle/sikmogilbackend/member/domain/Member.java
+++ b/src/main/java/com/examle/sikmogilbackend/member/domain/Member.java
@@ -62,6 +62,9 @@ public class Member {
     @Schema(description = "목표 날짜", example = "2024.06.02")
     private String targetDate;
 
+    @Schema(description = "먹을 수 있는 칼로리", example = "1000")
+    private Long canEatCalorie;
+
     @Schema(description = "생성 날짜", example = "2024.06.02")
     protected String createDate;
 
@@ -87,6 +90,7 @@ public class Member {
         this.targetWeight = onboardingInfoUpdateReqDto.targetWeight();
         this.targetDate = onboardingInfoUpdateReqDto.targetDate();
         this.createDate = onboardingInfoUpdateReqDto.createdDate();
+        this.canEatCalorie = onboardingInfoUpdateReqDto.canEatCalorie();
     }
 
     public void firstLongUpdate() {

--- a/src/main/java/com/examle/sikmogilbackend/member/domain/Member.java
+++ b/src/main/java/com/examle/sikmogilbackend/member/domain/Member.java
@@ -93,6 +93,19 @@ public class Member {
         this.canEatCalorie = onboardingInfoUpdateReqDto.canEatCalorie();
     }
 
+    public OnboardingInfoUpdateReqDto toDTO(){
+        return OnboardingInfoUpdateReqDto.builder()
+                .nickname(nickname)
+                .height(height)
+                .weight(weight)
+                .gender(gender)
+                .targetDate(targetDate)
+                .targetWeight(targetWeight)
+                .createdDate(createDate)
+                .canEatCalorie(canEatCalorie)
+                .build();
+    }
+
     public void firstLongUpdate() {
         this.firstLogin = false;
     }

--- a/src/main/java/com/examle/sikmogilbackend/record/Calendar/api/CalendarController.java
+++ b/src/main/java/com/examle/sikmogilbackend/record/Calendar/api/CalendarController.java
@@ -73,10 +73,24 @@ public class CalendarController {
             @ApiResponse(responseCode = "400", description = "잘못된 요청 값"),
             @ApiResponse(responseCode = "401", description = "헤더 없음 or 토큰 불일치", content = @Content(schema = @Schema(example = "INVALID_HEADER or INVALID_TOKEN")))
     })
-    @PostMapping("/UpdateCalendar")
+    @PostMapping("/updateCalendar")
     public RspTemplate<String> updateCalendar(Authentication authentication,
                                               @RequestBody CalendarDTO calendar){
         calendarService.UpdateCalendar(authentication.getName(), calendar);
         return new RspTemplate<>(HttpStatus.OK, "캘린더 데이터 입력 성공");
+    }
+
+    @Operation(summary = "특정 날짜의 몸무게 업데이트", description = "특정 날짜의 몸무게를 업데이트합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "특정 날짜의 몸무게 저장 성공"),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청 값"),
+            @ApiResponse(responseCode = "401", description = "헤더 없음 or 토큰 불일치", content = @Content(schema = @Schema(example = "INVALID_HEADER or INVALID_TOKEN")))
+    })
+    @PostMapping("/updateWeight")
+    public RspTemplate<String> updateWeight(Authentication authentication,
+                                              @RequestParam String date,
+                                              @RequestParam Long weight){
+        calendarService.updateWeight(authentication.getName(), date, weight);
+        return new RspTemplate<>(HttpStatus.OK, "특정 날짜의 몸무게 저장 성공");
     }
 }

--- a/src/main/java/com/examle/sikmogilbackend/record/Calendar/application/CalendarService.java
+++ b/src/main/java/com/examle/sikmogilbackend/record/Calendar/application/CalendarService.java
@@ -17,6 +17,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -49,10 +51,17 @@ public class CalendarService {
                 .map(Calendar::toWeekDTO)
                 .collect(Collectors.toList());
 
+        log.info("sort = "+weekWeights.toString());
+
+        Collections.sort( weekWeights, (o1, o2) -> o2.date().compareTo(o1.date()));
+
+        log.info("sort = "+weekWeights.toString());
+
+
         return MainCalendarDTO.builder()
                 .targetDate(member.getTargetDate())
                 .targetWeight(member.getTargetWeight())
-                .weekWeights(weekWeights)
+                .weekWeights(weekWeights.subList(0,7))
                 .build();
     }
 

--- a/src/main/java/com/examle/sikmogilbackend/record/Calendar/application/CalendarService.java
+++ b/src/main/java/com/examle/sikmogilbackend/record/Calendar/application/CalendarService.java
@@ -84,6 +84,15 @@ public class CalendarService {
     }
 
     @Transactional
+    public void updateWeight (String email, String date, Long weight) {
+        Member member = memberRepository.findByEmail(email).orElseThrow(MemberNotFoundException::new);
+
+        Calendar calendar = checkExistenceCalendar(member, date);
+
+        calendar.updateWeight(weight);
+    }
+
+    @Transactional
     public void createCalendar (Member member, String diaryDate) {
         log.info("캘린더 생성@@@@@@@@@@@@@");
         calendarRepository.save(

--- a/src/main/java/com/examle/sikmogilbackend/record/Calendar/domain/Calendar.java
+++ b/src/main/java/com/examle/sikmogilbackend/record/Calendar/domain/Calendar.java
@@ -74,9 +74,12 @@ public class Calendar {
     }
 
     public void updateCalendar(CalendarDTO calendarDTO){
-        this.diaryWeight = calendarDTO.diaryWeight();
         this.diaryDate = calendarDTO.diaryDate();
         this.diaryText = calendarDTO.diaryText();
+    }
+
+    public void updateWeight(Long weight){
+        this.diaryWeight = weight;
     }
 
 

--- a/src/main/java/com/examle/sikmogilbackend/record/WorkoutLog/api/WorkoutLogController.java
+++ b/src/main/java/com/examle/sikmogilbackend/record/WorkoutLog/api/WorkoutLogController.java
@@ -82,9 +82,8 @@ public class WorkoutLogController {
     })
     @PostMapping("/workoutList/addWorkoutList")
     public RspTemplate<String> addWorkoutList(Authentication authentication,
-                                              @RequestParam String date,
                                               @RequestBody WorkoutListDTO workoutList){
-        workoutListService.addWorkoutList(authentication.getName(),date, workoutList);
+        workoutListService.addWorkoutList(authentication.getName(), workoutList.date(), workoutList);
         return new RspTemplate<>(HttpStatus.OK, "운동 리스트 추가 성공");
     }
 

--- a/src/main/java/com/examle/sikmogilbackend/record/WorkoutLog/api/dto/WorkoutListDTO.java
+++ b/src/main/java/com/examle/sikmogilbackend/record/WorkoutLog/api/dto/WorkoutListDTO.java
@@ -5,6 +5,7 @@ import lombok.Builder;
 
 @Builder
 public record WorkoutListDTO(
+        String date,
         Long workoutListId,
         String performedWorkout,
         Long workoutTime,

--- a/src/main/java/com/examle/sikmogilbackend/record/dietLog/api/DietLogController.java
+++ b/src/main/java/com/examle/sikmogilbackend/record/dietLog/api/DietLogController.java
@@ -91,9 +91,8 @@ public class DietLogController {
     })
     @PostMapping("/dietList/addDietList")
     public RspTemplate<String> addDietList(Authentication authentication,
-                                           @RequestParam String date,
                                            @RequestBody DietListDTO dietList){
-        dietListService.addDietList(authentication.getName(),date,dietList);
+        dietListService.addDietList(authentication.getName(), dietList.date(), dietList);
         return new RspTemplate<>(HttpStatus.OK, "식단 추가 성공");
     }
 
@@ -132,9 +131,8 @@ public class DietLogController {
     })
     @PostMapping("/dietPicture/addDietPicture")
     public RspTemplate<String> addDietPicture(Authentication authentication,
-                                              @RequestParam String date,
                                               @RequestBody DietPictureDTO dietPictureDTO) {
-        dietPictureService.addDietPicture(authentication.getName(),date, dietPictureDTO);
+        dietPictureService.addDietPicture(authentication.getName(), dietPictureDTO.date(), dietPictureDTO);
         return new RspTemplate<>(HttpStatus.OK, "식단 사진 추가 성공");
     }
 

--- a/src/main/java/com/examle/sikmogilbackend/record/dietLog/api/DietLogController.java
+++ b/src/main/java/com/examle/sikmogilbackend/record/dietLog/api/DietLogController.java
@@ -1,6 +1,10 @@
 package com.examle.sikmogilbackend.record.dietLog.api;
 
 import com.examle.sikmogilbackend.global.template.RspTemplate;
+import com.examle.sikmogilbackend.member.application.MemberService;
+import com.examle.sikmogilbackend.member.domain.Member;
+import com.examle.sikmogilbackend.member.domain.repository.MemberRepository;
+import com.examle.sikmogilbackend.member.exception.MemberNotFoundException;
 import com.examle.sikmogilbackend.record.dietLog.api.dto.DietListDTO;
 import com.examle.sikmogilbackend.record.dietLog.api.dto.DietLogDTO;
 import com.examle.sikmogilbackend.record.dietLog.api.dto.DietPictureDTO;
@@ -29,6 +33,8 @@ public class DietLogController {
     private final DietListService dietListService;
     private final DietPictureService dietPictureService;
 
+    private final MemberRepository memberRepository;
+
     @Operation(summary = "사용자의 모든 식단 내역 출력", description = "사용자의 모든 식단 내용을 출력합니다.")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "식단 데이터 출력 성공"),
@@ -47,7 +53,8 @@ public class DietLogController {
     @GetMapping("/getDietLogDate")
     public DietLogDTO findDietLogByDietDate(Authentication authentication,
                                             @RequestParam String dietDate){
-        return dietLogService.findDietLogByDietDate(authentication.getName(), dietDate).toDTO();
+        Member member = memberRepository.findByEmail(authentication.getName()).orElseThrow(MemberNotFoundException::new);
+        return dietLogService.findDietLogByDietDate(authentication.getName(), dietDate).toDTO(member.getCanEatCalorie());
     }
 
     @Operation(summary = "특정 날짜의 식단 내용 업데이트", description = "특정 날짜의 식단을 업데이트합니다.")

--- a/src/main/java/com/examle/sikmogilbackend/record/dietLog/api/dto/DietListDTO.java
+++ b/src/main/java/com/examle/sikmogilbackend/record/dietLog/api/dto/DietListDTO.java
@@ -4,6 +4,7 @@ import lombok.Builder;
 
 @Builder
 public record DietListDTO(
+        String date,
         Long dietListId,
         Long calorie,
         String foodName,

--- a/src/main/java/com/examle/sikmogilbackend/record/dietLog/api/dto/DietLogDTO.java
+++ b/src/main/java/com/examle/sikmogilbackend/record/dietLog/api/dto/DietLogDTO.java
@@ -4,6 +4,7 @@ import lombok.Builder;
 
 @Builder
 public record DietLogDTO(
+        Long canEatCalorie,
         Long waterIntake,
         Long totalCalorieEaten,
         String dietDate

--- a/src/main/java/com/examle/sikmogilbackend/record/dietLog/api/dto/DietPictureDTO.java
+++ b/src/main/java/com/examle/sikmogilbackend/record/dietLog/api/dto/DietPictureDTO.java
@@ -4,6 +4,7 @@ import lombok.Builder;
 
 @Builder
 public record DietPictureDTO(
+        String date,
         Long dietPictureId,
         String foodPicture,
         String dietDate

--- a/src/main/java/com/examle/sikmogilbackend/record/dietLog/domain/DietLog.java
+++ b/src/main/java/com/examle/sikmogilbackend/record/dietLog/domain/DietLog.java
@@ -45,6 +45,15 @@ public class DietLog {
                 .build();
     }
 
+    public DietLogDTO toDTO(Long canEatCalorie){
+        return DietLogDTO.builder()
+                .canEatCalorie(canEatCalorie)
+                .waterIntake(waterIntake)
+                .totalCalorieEaten(totalCalorieEaten)
+                .dietDate(dietDate)
+                .build();
+    }
+
     public void updateDietLog(DietLogDTO dietLogDTO){
         this.dietDate = dietLogDTO.dietDate();
         this.waterIntake = dietLogDTO.waterIntake();


### PR DESCRIPTION

Feat(#7) : Member 먹을 수 있는 칼로리 생성 및 전체 체중 기록 -> 일주일 치 체중 기록 출력으로 변경

Feat(#9) : 특정 날짜의 식단 출력할 때 먹을 수 있는 칼로리까지 포함하여 출력

Feat(#7) : 일일 체중 저장하는 api 생성

Fix(#3) : requestParam과 requestBody 동시에 못사용해서 dto에 date 추가해서 requestBody로 받아버림.

Feat: 회원 정보 출력 api 생성